### PR TITLE
adding shell definition in copy runs

### DIFF
--- a/.github/actions/mkdocs-pages/action.yaml
+++ b/.github/actions/mkdocs-pages/action.yaml
@@ -39,6 +39,7 @@ runs:
           ${{ inputs.docs_folder }}
           ${{ inputs.docs_folder && '.github' }}
     - name: Copy defaults to docs folder
+      shell: bash
       run: |
         cp -rn ${{ github.action_path }}/default-docs/. 'docs/.';
         cp -rn ${{ github.action_path }}/. '.github/mkdocs/';


### PR DESCRIPTION
The template is causing errors in other repos G
```
GitHub.DistributedTask.ObjectTemplating.TemplateValidationException: The template is not valid. SciCatProject/docs-template/main/.github/actions/mkdocs-pages/action.yaml (Line: 41, Col: 7): Required property is missing: shell
   at GitHub.DistributedTask.ObjectTemplating.TemplateValidationErrors.Check()
   at GitHub.Runner.Worker.ActionManifestManager.ConvertRuns(IExecutionContext executionContext, TemplateContext templateContext, TemplateToken inputsToken, String fileRelativePath, MappingToken outputs)
   at GitHub.Runner.Worker.ActionManifestManager.Load(IExecutionContext executionContext, String manifestFile)
```
added shell definition to the copy command. 